### PR TITLE
検索条件をより細かく設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,17 +1,11 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :set_search
 
   def configure_permitted_parameters
     # 新規登録時
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     # 編集時
     devise_parameter_sanitizer.permit(:account_update, keys: [:name, :profile_image])
-  end
-
-  def set_search
-    @search_questions = Question.ransack(params[:q])
-    @searched_questions = @search_questions.result(distinct: true).recent
   end
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,4 +1,14 @@
 class SearchesController < ApplicationController
+  before_action :set_search
+
   def index
+    @categories = Category.all
+  end
+
+  private
+
+  def set_search
+    @search_questions = Question.ransack(params[:q])
+    @searched_questions = @search_questions.result(distinct: true).recent.page(params[:page]).per(10)
   end
 end

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -28,9 +28,3 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-light
       li.nav-item
         -if user_signed_in?
           = link_to '投稿', user_posts_path(current_user.id), class: 'nav-link'
-      / li.nav-item
-      /   .search-form
-      /     = search_form_for @search_questions, url: searches_path do |f|
-      /       = f.text_field :title_or_content_cont, placeholder: '質問を検索', required: :true
-      /       = button_tag type: :submit do 
-      /         = icon('fas', 'search')

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -9,6 +9,8 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-light
       li.nav-item
         = link_to 'カテゴリー', category_categories_path, class: 'nav-link'
       li.nav-item
+        = link_to icon('fas', 'search'), searches_path, class: 'nav-link'
+      li.nav-item
         - if user_signed_in?
           = link_to image_tag(current_user.profile_image, size: '30x30', class: 'rounded-circle'), user_path(current_user.id), class: 'nav-link'
           li.nav-item
@@ -26,9 +28,9 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-light
       li.nav-item
         -if user_signed_in?
           = link_to '投稿', user_posts_path(current_user.id), class: 'nav-link'
-      li.nav-item
-        .search-form
-          = search_form_for @search_questions, url: searches_path do |f|
-            = f.text_field :title_or_content_cont, placeholder: '質問を検索', required: :true
-            = button_tag type: :submit do 
-              = icon('fas', 'search')
+      / li.nav-item
+      /   .search-form
+      /     = search_form_for @search_questions, url: searches_path do |f|
+      /       = f.text_field :title_or_content_cont, placeholder: '質問を検索', required: :true
+      /       = button_tag type: :submit do 
+      /         = icon('fas', 'search')

--- a/app/views/searches/index.html.slim
+++ b/app/views/searches/index.html.slim
@@ -1,7 +1,31 @@
-h2.text-center.my-4 検索結果
+h2.text-center.my-3 検索
+.my-auto
+  = search_form_for @search_questions, url: searches_path do |f|
+    .text-center
+      = f.label :category_id_eq, 'カテゴリー', class: 'font-weight-bold lead'
+      br
+      .my-3
+        = f.collection_select :categories_id_eq, @categories, :id, :name, include_blank: '指定なし'
+      br
+      .mb-3
+        = f.radio_button :solved_eq, '', checked: true
+        | 指定なし
+        = f.radio_button :solved_eq, 0
+        | 未解決
+        = f.radio_button :solved_eq, 1
+        | 解決済み
+      br
+      = f.label :title_or_content_or_categories_name_cont, 'フリーワード検索', class: 'font-weight-bold lead mb-2'
+      br
+      = f.text_field :title_or_content_or_categories_name_cont, placeholder: '入力してください'
+      br
+      = f.submit '検索', class: 'btn btn-primary my-3'
+
+hr
 .question_index_container
   - if @searched_questions.present?
     p.text-danger
     = render partial: 'shared/question_index', collection: @searched_questions, as: :question
   - else
     p.text-center 一致する情報は見つかりませんでした。
+= paginate @searched_questions

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { 'Title' }
     content { "MyString" }
     user { create(:user) }
+    solved { 0 }
   end
 end

--- a/spec/system/searches_spec.rb
+++ b/spec/system/searches_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe "Searches", type: :system do
+  let!(:category1) { create(:category, name: 'category1') }
+  let!(:category2) { create(:category, name: 'category2') }
+  let!(:question) { create(:question, title: 'hoge', content: 'foo') }
+
+  before { visit searches_path }
+
+  describe '検索条件のテスト' do
+    describe '解決済みかどうかでの検索' do
+      context '未解決の場合' do
+        example '未解決の質問を返すこと' do
+          find('#q_solved_eq_0').click
+          click_button '検索'
+          expect(page).to have_content question.title
+        end
+
+        example '解決済みの質問は返さないこと' do
+          find('#q_solved_eq_1').click
+          click_button '検索'
+          expect(page).to have_content '一致する情報は見つかりませんでした。'
+        end
+      end
+
+      context '解決済みの場合' do
+        before { question.update_attribute(:solved, 1) }
+
+        example '解決済みの質問を返すこと' do
+          find('#q_solved_eq_1').click
+          click_button '検索'
+          expect(page).to have_content question.title
+        end
+
+        example '未解決の質問は返さないこと' do
+          find('#q_solved_eq_0').click
+          click_button '検索'
+          expect(page).to have_content '一致する情報は見つかりませんでした。'
+        end
+      end
+    end
+
+    describe 'カテゴリーの検索' do
+      before { question.categories << category1 }
+
+      example '選択したカテゴリーの質問を返すこと' do
+        select category1.name, from: 'q[categories_id_eq]'
+        click_button '検索'
+        expect(page).to have_content question.title
+      end
+
+      example '正しいカテゴリーの質問を返すこと' do
+        select category2.name, from: 'q[categories_id_eq]'
+        click_button '検索'
+        expect(page).to have_content '一致する情報は見つかりませんでした。'
+      end
+    end
+
+    describe 'フリーワード検索' do
+      example 'タイトルで検索できること' do
+        fill_in 'q[title_or_content_or_categories_name_cont]', with: 'hog'
+        click_button '検索'
+        expect(page).to have_content question.title
+      end
+
+      example '内容で検索できること' do
+        fill_in 'q[title_or_content_or_categories_name_cont]', with: 'fo'
+        click_button '検索'
+        expect(page).to have_content question.title
+      end
+
+      example 'カテゴリー名で検索できること' do
+        question.categories << category1
+        fill_in 'q[title_or_content_or_categories_name_cont]', with: 'catego'
+        click_button '検索'
+        expect(page).to have_content question.title
+      end
+
+      example '該当しない質問は返さないこと' do
+        fill_in 'q[title_or_content_or_categories_name_cont]', with: 'hello_world'
+        click_button '検索'
+        expect(page).to have_content '一致する情報は見つかりませんでした。'
+      end
+    end
+  end
+end


### PR DESCRIPTION
#81 
## Why
Q&Aサイトではある程度検索機能が充実していることが求められると感じたため

## 仕様
- カテゴリーを選択できる
- 解決済みかどうかを選択できる
- フリーワードで検索できる

## テスト項目
- 解決済みかどうかでの検索
  - 未解決の場合
    - 未解決の質問を返すこと
    - 解決済みの質問は返さないこと
  - 解決済みの場合
    - 解決済みの質問を返すこと
    - 未解決の質問は返さないこと
- カテゴリーの検索
  - 選択したカテゴリーの質問を返すこと
  - 正しいカテゴリーの質問を返すこと
- フリーワード検索
  - タイトルで検索できること
  - 内容で検索できること
  - カテゴリー名で検索できること
  - 該当しない質問は返さないこと