### PR TITLE
Feature/notification

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -160,3 +160,12 @@ body {
 .category_link {
   color: white;
 }
+
+//  通知ページのスタイリング
+
+.notification_container {
+  width: 880px;
+  margin: auto;
+  text-align: center;
+  font-size: 30px;
+}

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -5,6 +5,7 @@ class AnswersController < ApplicationController
   def create
     @answer = current_user.answers.build(answer_params)
     if @answer.save
+      current_user.create_notification_answer(@answer)
       flash[:success] = '回答しました'
       redirect_back(fallback_location: root_path)
     else

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,6 +5,7 @@ class CommentsController < ApplicationController
   def create
     @comment = @commentable.comments.build(comment_params)
     if @comment.save
+      @commentable.create_notification_comment(current_user, @comment)
       flash[:success] = 'コメントしました'
       redirect_back(fallback_location: root_path)
     else

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,10 @@
+class NotificationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @notifications = current_user.passive_notifications.where(checked: false).page(params[:page]).per(10)
+    @notifications.each do |notification|
+      notification.update_attributes(checked: true)
+    end
+  end
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,5 +1,7 @@
 class Answer < ApplicationRecord
   include Liked
+  include Commentable
+
   belongs_to :user
   belongs_to :question
 

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -1,0 +1,12 @@
+module Commentable
+  def create_notification_comment(current_user, comment)
+    temp_ids = comments.select(:user_id).where.not(user_id: current_user.id)
+    if temp_ids.blank?
+      current_user.save_notification_comment(comment, comment.commentable.user.id)
+    else
+      temp_ids.each do |temp_id|
+        comment.user.save_notification_comment(comment, temp_id[:user_id])
+      end
+    end
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,2 +1,6 @@
 class Notification < ApplicationRecord
+  belongs_to :answer, optional: true
+  belongs_to :comment, optional: true
+  belongs_to :visitor, class_name: 'User', foreign_key: 'visitor_id'
+  belongs_to :visited, class_name: 'User', foreign_key: 'visited_id'
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,2 @@
+class Notification < ApplicationRecord
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,7 @@ class Post < ApplicationRecord
   include Taggable
   include Liked
   include CommonScope
+  include Commentable
 
   belongs_to :user
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -49,6 +49,9 @@ class Question < ApplicationRecord
       visited: answer.user,
       action: 'best_answer'
     )
+    if notification.visitor == notification.visited
+      notification.checked = true
+    end
     notification.save if notification.valid?
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,6 +2,7 @@ class Question < ApplicationRecord
   include Liked
   include Taggable
   include CommonScope
+  include Commentable
 
   belongs_to :user
 
@@ -37,6 +38,17 @@ class Question < ApplicationRecord
     if answers.include?(answer) && best_answer.blank?
       self.best_answer = answer
       update_attribute(:solved, 1)
+      create_notification_best_answer(answer)
     end
+  end
+
+  def create_notification_best_answer(answer)
+    notification = user.active_notifications.new(
+      answer: answer,
+      visitor: user,
+      visited: answer.user,
+      action: 'best_answer'
+    )
+    notification.save if notification.valid?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,6 +98,9 @@ class User < ApplicationRecord
       visited: answer.question.user,
       action: 'answer'
     )
+    if notification.visitor == notification.visited
+      notification.checked = true
+    end
     notification.save if notification.valid?
   end
 

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -24,6 +24,9 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-light
           = link_to '質問する', new_question_path, class: 'nav-link'
       li.nav-item
         - if user_signed_in?
+          = link_to icon('fas', 'bell'), notifications_path, class: (current_user.has_notifications? ? 'nav-link text-danger' : 'nav-link')
+      li.nav-item
+        - if user_signed_in?
           = link_to 'ストック一覧', user_stocks_path(current_user.id), class: 'nav-link'
       li.nav-item
         -if user_signed_in?

--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -1,0 +1,24 @@
+- visitor = notification.visitor
+- visited = notification.visited
+= link_to "#{visitor.name}さんが", user_path(visitor.id)
+- case notification.action
+- when 'follow' then
+  | あなたをフォローしました
+- when 'answer' then
+  = link_to 'あなたの質問', question_path(notification.answer.question.id)
+  | に回答しました
+- when 'best_answer' then
+  = link_to 'あなたの回答', question_path(notification.answer.id)
+  | をベストアンサーに決定しました
+- when 'comment' then
+  - case notification.comment.commentable_type
+  - when 'Question' then
+    = link_to '質問', question_path(notification.comment.commentable.id)
+    | にコメントしました
+  - when 'Answer' then
+    = link_to '質問の回答', question_path(notification.comment.commentable.id)
+    | にコメントしました
+  - when 'Post' then
+    = link_to '投稿', post_path(notification.comment.commentable.id)
+    | にコメントしました
+hr

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -1,0 +1,6 @@
+.notification_container
+  - if @notifications.present?
+    = render partial: 'notifications/notification', collection: @notifications, as: :notification
+    = paginate @notifications
+  - else
+    p  通知はありません

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,4 +35,6 @@ Rails.application.routes.draw do
   resources :best_answers, only: :create
 
   resources :searches, only: :index
+
+  resources :notifications, only: :index
 end

--- a/db/migrate/20200318113249_create_notifications.rb
+++ b/db/migrate/20200318113249_create_notifications.rb
@@ -1,0 +1,17 @@
+class CreateNotifications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :notifications do |t|
+      t.integer :visitor_id, null: false
+      t.integer :visited_id, null: false
+      t.integer :answer_id
+      t.integer :comment_id
+      t.string :action, default: '', null: false
+      t.boolean :checked, default: false, null: false
+      t.timestamps
+    end
+
+    add_index :notifications, :visitor_id
+    add_index :notifications, :visited_id
+    add_index :notifications, :comment_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200318000412) do
+ActiveRecord::Schema.define(version: 20200318113249) do
 
   create_table "answers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.text "content"
@@ -47,6 +47,20 @@ ActiveRecord::Schema.define(version: 20200318000412) do
     t.datetime "updated_at", null: false
     t.index ["likable_type", "likable_id"], name: "index_likes_on_likable_type_and_likable_id"
     t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "notifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "visitor_id", null: false
+    t.integer "visited_id", null: false
+    t.integer "answer_id"
+    t.integer "comment_id"
+    t.string "action", default: "", null: false
+    t.boolean "checked", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["comment_id"], name: "index_notifications_on_comment_id"
+    t.index ["visited_id"], name: "index_notifications_on_visited_id"
+    t.index ["visitor_id"], name: "index_notifications_on_visitor_id"
   end
 
   create_table "posts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :post do
-    user { nil }
+    user { create(:user) }
     content { "MyText" }
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -62,4 +62,20 @@ RSpec.describe Comment, type: :model do
       expect { user.destroy }.to change(Comment, :count).by(-1)
     end
   end
+
+  describe '通知関連' do
+    describe 'create_notification_comment(comment, visited_id)' do
+      before do
+        comment.save
+        user.save_notification_comment(comment, comment.commentable.user.id)
+      end
+
+      example '正しい通知が作成されていること' do
+        expect(Notification.first.visitor).to eq comment.user
+        expect(Notification.first.visited).to eq comment.commentable.user
+        expect(Notification.first.action).to eq 'comment'
+        expect(Notification.first.comment).to eq comment
+      end
+    end
+  end
 end

--- a/spec/models/commentable_spec.rb
+++ b/spec/models/commentable_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Commentable, type: :model do
+  shared_examples 'コメント通知のテスト' do
+    let!(:comment) { create(:comment, commentable: commentable) }
+    context '他にコメントがない場合' do
+      before { comment.commentable.create_notification_comment(comment.user, comment) }
+
+      example 'commetable.user宛の通知が作成できていること' do
+        expect(Notification.first.visitor).to eq comment.user
+        expect(Notification.first.visited).to eq comment.commentable.user
+        expect(Notification.first.comment).to eq comment
+        expect(Notification.first.action).to eq 'comment'
+      end
+    end
+
+    context '他にコメントがある場合' do
+      let!(:other_comment) { create(:comment, commentable: commentable) }
+
+      before { comment.commentable.create_notification_comment(other_comment.user, other_comment) }
+
+      example '先にコメントした人宛の通知が作成されていること' do
+        expect(comment.user.passive_notifications.first.visitor).to eq other_comment.user
+        expect(comment.user.passive_notifications.first.visited).to eq comment.user
+        expect(comment.user.passive_notifications.first.action).to eq 'comment'
+        expect(comment.user.passive_notifications.first.comment).to eq other_comment
+      end
+    end
+  end
+
+  describe 'commentable => question' do
+    include_examples 'コメント通知のテスト' do
+      let!(:commentable) { create(:question) }
+    end
+  end
+
+  describe 'commentable => post' do
+    include_examples 'コメント通知のテスト' do
+      let!(:commentable) { create(:post) }
+    end
+  end
+
+  describe 'commentable => answer' do
+    include_examples 'コメント通知のテスト' do
+      let!(:commentable) { create(:answer) }
+    end
+  end
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -65,11 +65,24 @@ RSpec.describe Question, type: :model do
       end
     end
 
+    describe 'create_notification_best_answer(answer)' do
+      before { question.create_notification_best_answer(answer) }
+
+      example 'ベストアンサーの通知が作成できている事' do
+        expect(Notification.first.visitor).to eq question.user
+        expect(Notification.first.visited).to eq answer.user
+        expect(Notification.first.answer).to eq answer
+        expect(Notification.first.action).to eq 'best_answer'
+      end
+    end
+
     describe 'decide_best_answer(answer)' do
       example 'ベストアンサーを決定できること' do
         expect do
           question.decide_best_answer(answer)
-        end.to change(question, :best_answer).from(nil).to(answer).and change(question, :solved).from(0).to(1)
+        end.to change(question, :best_answer).from(nil).to(answer).
+          and change(question, :solved).from(0).to(1).
+          and change(Notification, :count).by(1)
       end
 
       context '既にベストアンサーが決定している場合' do

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -66,13 +66,26 @@ RSpec.describe Question, type: :model do
     end
 
     describe 'create_notification_best_answer(answer)' do
-      before { question.create_notification_best_answer(answer) }
+      context '回答者が質問者と異なる場合' do
+        before { question.create_notification_best_answer(answer) }
 
-      example 'ベストアンサーの通知が作成できている事' do
-        expect(Notification.first.visitor).to eq question.user
-        expect(Notification.first.visited).to eq answer.user
-        expect(Notification.first.answer).to eq answer
-        expect(Notification.first.action).to eq 'best_answer'
+        example 'ベストアンサーの通知が作成できている事' do
+          expect(Notification.first.visitor).to eq question.user
+          expect(Notification.first.visited).to eq answer.user
+          expect(Notification.first.answer).to eq answer
+          expect(Notification.first.action).to eq 'best_answer'
+        end
+      end
+
+      context '回答者が質問者本人の場合' do
+        let(:other_answer) { create(:answer, question: question, user: question.user) }
+
+        before { question.create_notification_best_answer(other_answer) }
+
+        example '既読扱いの通知が作成されていること' do
+          expect(Notification.first.visitor == Notification.first.visited).to eq true
+          expect(Notification.first.checked).to eq true
+        end
       end
     end
 

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe "Notifications", type: :request do
+  let!(:user) { create(:user) }
+
+  describe 'index' do
+    context 'ログインしている時' do
+      before do
+        sign_in user
+        get notifications_path
+      end
+
+      example '200レスポンスを返すこと' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'ログインしていない時' do
+      before { get notifications_path }
+
+      example 'サインイン画面へリダイレクトされること' do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+end

--- a/spec/system/notifications_spec.rb
+++ b/spec/system/notifications_spec.rb
@@ -1,0 +1,157 @@
+require 'rails_helper'
+
+RSpec.describe "Notifications", type: :system do
+  describe '通知ページのテスト' do
+    let!(:user) { create(:user) }
+    let!(:other_user) { create(:user) }
+    let!(:question) { create(:question, user: user) }
+    let!(:answer) { create(:answer, user: other_user, question: question) }
+
+    before { login_as user, scope: :user }
+
+    shared_examples '通知が存在しないこと' do
+      example '通知が作成されていないこと' do
+        expect(page).to have_content '通知はありません'
+      end
+    end
+
+    describe 'フォロー通知' do
+      before do
+        other_user.follow(user)
+        visit notifications_path
+      end
+
+      example '通知されていること' do
+        expect(page).to have_content "#{other_user.name}さんがあなたをフォローしました"
+      end
+
+      context 'フォローボタンを連打された時' do
+        before do
+          other_user.unfollow(user)
+          other_user.follow(user)
+          visit notifications_path
+        end
+
+        include_examples '通知が存在しないこと'
+      end
+    end
+
+    describe '回答通知' do
+      context '回答者が質問者本人でない場合' do
+        before do
+          other_user.create_notification_answer(answer)
+          visit notifications_path
+        end
+
+        example '通知されていること' do
+          expect(page).to have_content "#{other_user.name}さんがあなたの質問に回答しました"
+        end
+      end
+
+      context '回答者が質問者本人の場合' do
+        let!(:other_answer) { create(:answer, question: question, user: user) }
+
+        before do
+          other_answer.user.create_notification_answer(other_answer)
+          visit notifications_path
+        end
+
+        include_examples '通知が存在しないこと'
+      end
+    end
+
+    describe 'ベストアンサー通知' do
+      context '回答者と質問者が異なる場合' do
+        before do
+          login_as other_user, scope: :user
+          question.decide_best_answer(answer)
+          visit notifications_path
+        end
+
+        example '通知されていること' do
+          expect(page).to have_content "#{user.name}さんがあなたの回答をベストアンサーに決定しました"
+        end
+      end
+
+      context '質問者本人の場合' do
+        let!(:user_answer) { create(:answer, question: question, user: user) }
+
+        before do
+          question.decide_best_answer(user_answer)
+          visit notifications_path
+        end
+
+        include_examples '通知が存在しないこと'
+      end
+    end
+
+    describe 'コメント通知' do
+      shared_examples 'コメント通知のテスト' do
+        let!(:comment) { create(:comment, commentable: commentable) }
+
+        describe 'commentable.user以外がコメントした場合' do
+          context '事前にコメントされてない場合' do
+            before do
+              login_as comment.commentable.user, scope: :user
+              comment.commentable.create_notification_comment(comment.user, comment)
+              visit notifications_path
+            end
+
+            example 'commentable.userへの通知されていること' do
+              expect(page).to have_content first_notification_text
+            end
+          end
+
+          context '事前にコメントされている場合' do
+            let!(:other_comment) { create(:comment, commentable: commentable) }
+
+            before do
+              other_comment.commentable.create_notification_comment(other_comment.user, other_comment)
+              login_as comment.user, scope: :user
+              visit notifications_path
+            end
+
+            example '事前にコメントしているユーザーへ通知されていること' do
+              expect(page).to have_content second_notification_text
+            end
+          end
+        end
+
+        describe 'commentable.userがコメントした場合' do
+          let!(:comment) { create(:comment, commentable: commentable, user: commentable.user) }
+
+          before do
+            comment.commentable.create_notification_comment(comment.user, comment)
+            visit notifications_path
+          end
+
+          include_examples '通知が存在しないこと'
+        end
+      end
+
+      describe 'commentable => question' do
+        include_examples 'コメント通知のテスト' do
+          let(:first_notification_text) { "#{comment.user.name}さんが質問にコメントしました" }
+          let(:second_notification_text) { "#{other_comment.user.name}さんが質問にコメントしました" }
+          let!(:commentable) { question }
+        end
+      end
+
+      describe 'commentable => answer' do
+        include_examples 'コメント通知のテスト' do
+          let(:first_notification_text) { "#{comment.user.name}さんが質問の回答にコメントしました" }
+          let(:second_notification_text) { "#{other_comment.user.name}さんが質問の回答にコメントしました" }
+          let!(:commentable) { create(:answer) }
+        end
+      end
+
+      describe 'commentable => answer' do
+        include_examples 'コメント通知のテスト' do
+          let(:first_notification_text) { "#{comment.user.name}さんが投稿にコメントしました" }
+          let(:second_notification_text) { "#{other_comment.user.name}さんが投稿にコメントしました" }
+          let!(:commentable) { create(:post) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#26 

## 要件

以下のアクション時に通知を送る

-  フォローされた時
- 回答が来た時
- 質問、回答、投稿に対してコメントが来た時
- ベストアンサーに決定された時

## 仕様

-  フォローされた時
  - フォローボタンを連打されても送られる通知は一回のみ
- 回答が来た時
  - 本人が回答した場合、通知されない
- 質問、回答、投稿に対してコメントが来た時
  - 本人がコメントした場合、通知されない
  - 事前にコメントがある場合、そのコメントをしたユーザーにも通知される（コメントのやりとりをスムーズに行ってもらうため）
- ベストアンサーに決定された時
  - 回答が質問者本人のものである場合、通知されない